### PR TITLE
chore: ビルドパイプライン構築 + npm install -g 対応

### DIFF
--- a/bin/backlog.ts
+++ b/bin/backlog.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env tsx
+#!/usr/bin/env node
 import { createProgram } from "../src/index.js";
 
 const program = createProgram();

--- a/package.json
+++ b/package.json
@@ -1,13 +1,18 @@
 {
-  "name": "backlog-cli",
+  "name": "@morodomi/backlog-cli",
   "version": "0.1.0",
   "description": "CLI tool for backlog.jp (Nulab)",
   "type": "module",
   "bin": {
-    "backlog": "./bin/backlog.ts"
+    "backlog": "./dist/bin/backlog.js"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "dev": "tsx bin/backlog.ts",
+    "build": "tsc -p tsconfig.build.json",
+    "prepublishOnly": "pnpm build",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/tests/unit/build.test.ts
+++ b/tests/unit/build.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { execSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { rmSync } from "node:fs";
+
+describe("ビルドパイプライン", () => {
+  beforeAll(() => {
+    // dist/ をクリーンアップしてからビルド
+    rmSync("dist", { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    // テスト後にクリーンアップ
+    rmSync("dist", { recursive: true, force: true });
+  });
+
+  it("pnpm build が成功する", () => {
+    expect(() => {
+      execSync("pnpm build", { stdio: "pipe" });
+    }).not.toThrow();
+  });
+
+  it("dist/bin/backlog.js が生成される", () => {
+    execSync("pnpm build", { stdio: "pipe" });
+    expect(existsSync("dist/bin/backlog.js")).toBe(true);
+  });
+
+  it("dist/src/index.js が生成される", () => {
+    execSync("pnpm build", { stdio: "pipe" });
+    expect(existsSync("dist/src/index.js")).toBe(true);
+  });
+
+  it("dist/bin/backlog.js に shebang が含まれる", () => {
+    execSync("pnpm build", { stdio: "pipe" });
+    const content = readFileSync("dist/bin/backlog.js", "utf-8");
+    expect(content.startsWith("#!/usr/bin/env node")).toBe(true);
+  });
+
+  it("dist/ にテストファイルが含まれない", () => {
+    execSync("pnpm build", { stdio: "pipe" });
+    expect(existsSync("dist/tests")).toBe(false);
+  });
+
+  it("package.json の bin が dist/bin/backlog.js を指す", () => {
+    const pkg = JSON.parse(readFileSync("package.json", "utf-8"));
+    expect(pkg.bin.backlog).toBe("./dist/bin/backlog.js");
+  });
+
+  it("package.json の files に dist が含まれる", () => {
+    const pkg = JSON.parse(readFileSync("package.json", "utf-8"));
+    expect(pkg.files).toContain("dist");
+  });
+
+  it("package.json に build スクリプトがある", () => {
+    const pkg = JSON.parse(readFileSync("package.json", "utf-8"));
+    expect(pkg.scripts.build).toBeDefined();
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "."
+  },
+  "include": ["src/**/*", "bin/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}


### PR DESCRIPTION
## Summary
- `tsconfig.build.json` 追加 (テスト除外のビルド専用設定)
- `package.json`: bin を `dist/bin/backlog.js` に変更、build/prepublishOnly スクリプト追加、files フィールド追加
- `bin/backlog.ts`: shebang を `node` に変更 (ビルド後の .js 用)
- ビルドパイプラインのテスト追加 (8テスト)

## Test plan
- [x] `pnpm build` → `dist/` 生成
- [x] `npm install -g .` → グローバルインストール成功
- [x] `backlog --version` → `0.1.0` 表示
- [x] `backlog --help` → コマンド一覧表示
- [x] `backlog auth status` → 正常動作
- [x] `pnpm test` → 65テスト全パス
- [x] `npx tsc --noEmit` → エラー0件
- [x] `pnpm lint` → エラー0件
- [x] `pnpm format:check` → 全ファイルOK

🤖 Generated with [Claude Code](https://claude.com/claude-code)