### PR TITLE
feat: issue list フィルタ拡張 + project メタデータ list コマンド

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,10 +60,24 @@ docs/cycles/              # Cycle docs
 ## CLIコマンド
 
 ```bash
+# 認証
 backlog auth login --host xxx.backlog.jp --api-key KEY
 backlog auth status
+
+# プロジェクト
 backlog project list [--archived] [--json]
-backlog issue list -p PROJECT_KEY [--status ...] [--limit N] [--json]
+backlog project statuses <projectKey> [--json]
+backlog project types <projectKey> [--json]
+backlog project categories <projectKey> [--json]
+backlog project milestones <projectKey> [--json]
+backlog project members <projectKey> [--json]
+
+# 課題
+backlog issue list -p PROJECT_KEY [--status ...] [--type ...] [--category ...]
+                                  [--milestone ...] [--assignee ...]
+                                  [--priority ...] [--keyword <text>]
+                                  [--sort <key>] [--order asc|desc]
+                                  [--limit N] [--json]
 backlog issue view ISSUE_KEY [--json]
 ```
 

--- a/src/commands/issue/list.ts
+++ b/src/commands/issue/list.ts
@@ -2,41 +2,99 @@ import type { Command } from "commander";
 import type { IssueService, IssueListOptions } from "../../services/issue.service.js";
 import { formatIssueTable } from "../../formatters/table.formatter.js";
 
+interface IssueListCommandOptions {
+  project: string;
+  status?: string[];
+  type?: string[];
+  category?: string[];
+  milestone?: string[];
+  assignee?: string[];
+  priority?: string[];
+  keyword?: string;
+  sort?: string;
+  order?: "asc" | "desc";
+  limit?: number;
+  json?: boolean;
+}
+
 export function registerIssueListCommand(program: Command, issueService: IssueService): void {
   program
     .command("list")
     .description("課題一覧を表示する")
     .requiredOption("-p, --project <projectKey>", "プロジェクトキー")
     .option("--status <status...>", "ステータスでフィルタ")
+    .option("--type <type...>", "種別でフィルタ")
+    .option("--category <category...>", "カテゴリでフィルタ")
+    .option("--milestone <milestone...>", "マイルストーンでフィルタ")
+    .option("--assignee <assignee...>", "担当者でフィルタ")
+    .option("--priority <priority...>", "優先度でフィルタ")
+    .option("--keyword <text>", "キーワード検索")
+    .option("--sort <key>", "ソートキー")
+    .option("--order <order>", "ソート順 (asc|desc)")
     .option("--limit <number>", "取得件数", parseInt)
     .option("--json", "JSON形式で出力する")
-    .action(
-      async (options: { project: string; status?: string[]; limit?: number; json?: boolean }) => {
-        try {
-          const listOptions: IssueListOptions = {
-            projectKey: options.project,
-          };
+    .action(async (options: IssueListCommandOptions) => {
+      try {
+        const listOptions: IssueListOptions = {
+          projectKey: options.project,
+        };
 
-          if (options.status) {
-            const statusIds = await issueService.resolveStatusIds(options.project, options.status);
-            listOptions.statusId = statusIds;
-          }
-
-          if (options.limit) {
-            listOptions.limit = options.limit;
-          }
-
-          const issues = await issueService.list(listOptions);
-
-          if (options.json) {
-            console.log(JSON.stringify(issues, null, 2));
-          } else {
-            console.log(formatIssueTable(issues));
-          }
-        } catch (e) {
-          console.error(e instanceof Error ? e.message : String(e));
-          process.exitCode = 1;
+        if (options.status) {
+          listOptions.statusId = await issueService.resolveStatusIds(
+            options.project,
+            options.status,
+          );
         }
-      },
-    );
+        if (options.type) {
+          listOptions.issueTypeId = await issueService.resolveIssueTypeIds(
+            options.project,
+            options.type,
+          );
+        }
+        if (options.category) {
+          listOptions.categoryId = await issueService.resolveCategoryIds(
+            options.project,
+            options.category,
+          );
+        }
+        if (options.milestone) {
+          listOptions.milestoneId = await issueService.resolveMilestoneIds(
+            options.project,
+            options.milestone,
+          );
+        }
+        if (options.assignee) {
+          listOptions.assigneeId = await issueService.resolveAssigneeIds(
+            options.project,
+            options.assignee,
+          );
+        }
+        if (options.priority) {
+          listOptions.priorityId = await issueService.resolvePriorityIds(options.priority);
+        }
+        if (options.keyword) {
+          listOptions.keyword = options.keyword;
+        }
+        if (options.sort) {
+          listOptions.sort = options.sort;
+        }
+        if (options.order) {
+          listOptions.order = options.order;
+        }
+        if (options.limit) {
+          listOptions.limit = options.limit;
+        }
+
+        const issues = await issueService.list(listOptions);
+
+        if (options.json) {
+          console.log(JSON.stringify(issues, null, 2));
+        } else {
+          console.log(formatIssueTable(issues));
+        }
+      } catch (e) {
+        console.error(e instanceof Error ? e.message : String(e));
+        process.exitCode = 1;
+      }
+    });
 }

--- a/src/commands/project/categories.ts
+++ b/src/commands/project/categories.ts
@@ -1,0 +1,27 @@
+import type { Command } from "commander";
+import type { ProjectService } from "../../services/project.service.js";
+import { formatCategoryTable } from "../../formatters/table.formatter.js";
+
+export function registerProjectCategoriesCommand(
+  program: Command,
+  projectService: ProjectService,
+): void {
+  program
+    .command("categories <projectKey>")
+    .description("プロジェクトのカテゴリ一覧を表示する")
+    .option("--json", "JSON形式で出力する")
+    .action(async (projectKey: string, options: { json?: boolean }) => {
+      try {
+        const categories = await projectService.getCategories(projectKey);
+
+        if (options.json) {
+          console.log(JSON.stringify(categories, null, 2));
+        } else {
+          console.log(formatCategoryTable(categories));
+        }
+      } catch (e) {
+        console.error(e instanceof Error ? e.message : String(e));
+        process.exitCode = 1;
+      }
+    });
+}

--- a/src/commands/project/index.ts
+++ b/src/commands/project/index.ts
@@ -1,9 +1,19 @@
 import { Command } from "commander";
 import type { ProjectService } from "../../services/project.service.js";
 import { registerProjectListCommand } from "./list.js";
+import { registerProjectStatusesCommand } from "./statuses.js";
+import { registerProjectTypesCommand } from "./types.js";
+import { registerProjectCategoriesCommand } from "./categories.js";
+import { registerProjectMilestonesCommand } from "./milestones.js";
+import { registerProjectMembersCommand } from "./members.js";
 
 export function createProjectCommand(projectService: ProjectService): Command {
   const project = new Command("project").description("プロジェクトの管理");
   registerProjectListCommand(project, projectService);
+  registerProjectStatusesCommand(project, projectService);
+  registerProjectTypesCommand(project, projectService);
+  registerProjectCategoriesCommand(project, projectService);
+  registerProjectMilestonesCommand(project, projectService);
+  registerProjectMembersCommand(project, projectService);
   return project;
 }

--- a/src/commands/project/members.ts
+++ b/src/commands/project/members.ts
@@ -1,0 +1,27 @@
+import type { Command } from "commander";
+import type { ProjectService } from "../../services/project.service.js";
+import { formatMemberTable } from "../../formatters/table.formatter.js";
+
+export function registerProjectMembersCommand(
+  program: Command,
+  projectService: ProjectService,
+): void {
+  program
+    .command("members <projectKey>")
+    .description("プロジェクトのメンバー一覧を表示する")
+    .option("--json", "JSON形式で出力する")
+    .action(async (projectKey: string, options: { json?: boolean }) => {
+      try {
+        const members = await projectService.getMembers(projectKey);
+
+        if (options.json) {
+          console.log(JSON.stringify(members, null, 2));
+        } else {
+          console.log(formatMemberTable(members));
+        }
+      } catch (e) {
+        console.error(e instanceof Error ? e.message : String(e));
+        process.exitCode = 1;
+      }
+    });
+}

--- a/src/commands/project/milestones.ts
+++ b/src/commands/project/milestones.ts
@@ -1,0 +1,27 @@
+import type { Command } from "commander";
+import type { ProjectService } from "../../services/project.service.js";
+import { formatVersionTable } from "../../formatters/table.formatter.js";
+
+export function registerProjectMilestonesCommand(
+  program: Command,
+  projectService: ProjectService,
+): void {
+  program
+    .command("milestones <projectKey>")
+    .description("プロジェクトのマイルストーン一覧を表示する")
+    .option("--json", "JSON形式で出力する")
+    .action(async (projectKey: string, options: { json?: boolean }) => {
+      try {
+        const versions = await projectService.getVersions(projectKey);
+
+        if (options.json) {
+          console.log(JSON.stringify(versions, null, 2));
+        } else {
+          console.log(formatVersionTable(versions));
+        }
+      } catch (e) {
+        console.error(e instanceof Error ? e.message : String(e));
+        process.exitCode = 1;
+      }
+    });
+}

--- a/src/commands/project/statuses.ts
+++ b/src/commands/project/statuses.ts
@@ -1,0 +1,27 @@
+import type { Command } from "commander";
+import type { ProjectService } from "../../services/project.service.js";
+import { formatStatusTable } from "../../formatters/table.formatter.js";
+
+export function registerProjectStatusesCommand(
+  program: Command,
+  projectService: ProjectService,
+): void {
+  program
+    .command("statuses <projectKey>")
+    .description("プロジェクトのステータス一覧を表示する")
+    .option("--json", "JSON形式で出力する")
+    .action(async (projectKey: string, options: { json?: boolean }) => {
+      try {
+        const statuses = await projectService.getStatuses(projectKey);
+
+        if (options.json) {
+          console.log(JSON.stringify(statuses, null, 2));
+        } else {
+          console.log(formatStatusTable(statuses));
+        }
+      } catch (e) {
+        console.error(e instanceof Error ? e.message : String(e));
+        process.exitCode = 1;
+      }
+    });
+}

--- a/src/commands/project/types.ts
+++ b/src/commands/project/types.ts
@@ -1,0 +1,27 @@
+import type { Command } from "commander";
+import type { ProjectService } from "../../services/project.service.js";
+import { formatIssueTypeTable } from "../../formatters/table.formatter.js";
+
+export function registerProjectTypesCommand(
+  program: Command,
+  projectService: ProjectService,
+): void {
+  program
+    .command("types <projectKey>")
+    .description("プロジェクトの種別一覧を表示する")
+    .option("--json", "JSON形式で出力する")
+    .action(async (projectKey: string, options: { json?: boolean }) => {
+      try {
+        const types = await projectService.getIssueTypes(projectKey);
+
+        if (options.json) {
+          console.log(JSON.stringify(types, null, 2));
+        } else {
+          console.log(formatIssueTypeTable(types));
+        }
+      } catch (e) {
+        console.error(e instanceof Error ? e.message : String(e));
+        process.exitCode = 1;
+      }
+    });
+}

--- a/src/formatters/table.formatter.ts
+++ b/src/formatters/table.formatter.ts
@@ -1,5 +1,16 @@
 import type { Entity } from "backlog-js";
 
+type RoleType = 1 | 2 | 3 | 4 | 5 | 6;
+
+const ROLE_NAMES: Record<RoleType, string> = {
+  1: "管理者",
+  2: "一般",
+  3: "レポーター",
+  4: "ビューアー",
+  5: "ゲストレポーター",
+  6: "ゲストビューアー",
+};
+
 export function formatProjectTable(projects: Entity.Project.Project[]): string {
   if (projects.length === 0) {
     return "プロジェクトが見つかりません";
@@ -27,6 +38,78 @@ export function formatIssueTable(issues: Entity.Issue.Issue[]): string {
       padEnd(i.status.name, 12) +
       padEnd(i.assignee?.name ?? "-", 16) +
       i.summary,
+  );
+
+  return [header, separator, ...rows].join("\n");
+}
+
+export function formatStatusTable(statuses: Entity.Project.ProjectStatus[]): string {
+  if (statuses.length === 0) {
+    return "ステータスが見つかりません";
+  }
+
+  const header = padEnd("Name", 20) + "Color";
+  const separator = "-".repeat(header.length);
+  const rows = statuses.map((s) => padEnd(s.name, 20) + s.color);
+
+  return [header, separator, ...rows].join("\n");
+}
+
+export function formatIssueTypeTable(types: Entity.Issue.IssueType[]): string {
+  if (types.length === 0) {
+    return "種別が見つかりません";
+  }
+
+  const header = padEnd("Name", 20) + "Color";
+  const separator = "-".repeat(header.length);
+  const rows = types.map((t) => padEnd(t.name, 20) + t.color);
+
+  return [header, separator, ...rows].join("\n");
+}
+
+export function formatCategoryTable(categories: Entity.Project.Category[]): string {
+  if (categories.length === 0) {
+    return "カテゴリが見つかりません";
+  }
+
+  const header = "Name";
+  const separator = "-".repeat(30);
+  const rows = categories.map((c) => c.name);
+
+  return [header, separator, ...rows].join("\n");
+}
+
+export function formatVersionTable(versions: Entity.Project.Version[]): string {
+  if (versions.length === 0) {
+    return "バージョンが見つかりません";
+  }
+
+  const header =
+    padEnd("Name", 20) + padEnd("StartDate", 14) + padEnd("ReleaseDueDate", 18) + "Archived";
+  const separator = "-".repeat(header.length);
+  const rows = versions.map(
+    (v) =>
+      padEnd(v.name, 20) +
+      padEnd(v.startDate ?? "-", 14) +
+      padEnd(v.releaseDueDate ?? "-", 18) +
+      (v.archived ? "Yes" : "No"),
+  );
+
+  return [header, separator, ...rows].join("\n");
+}
+
+export function formatMemberTable(members: Entity.User.User[]): string {
+  if (members.length === 0) {
+    return "メンバーが見つかりません";
+  }
+
+  const header = padEnd("Name", 20) + padEnd("UserId", 20) + "Role";
+  const separator = "-".repeat(header.length);
+  const rows = members.map(
+    (m) =>
+      padEnd(m.name, 20) +
+      padEnd(m.userId ?? "-", 20) +
+      (ROLE_NAMES[m.roleType as RoleType] ?? String(m.roleType)),
   );
 
   return [header, separator, ...rows].join("\n");

--- a/src/services/issue.service.ts
+++ b/src/services/issue.service.ts
@@ -3,7 +3,14 @@ import type { Backlog, Entity } from "backlog-js";
 export interface IssueListOptions {
   projectKey: string;
   statusId?: number[];
+  issueTypeId?: number[];
+  categoryId?: number[];
+  milestoneId?: number[];
   assigneeId?: number[];
+  priorityId?: number[];
+  keyword?: string;
+  sort?: string;
+  order?: "asc" | "desc";
   limit?: number;
 }
 
@@ -18,8 +25,29 @@ export class IssueService {
     if (options.statusId) {
       params["statusId"] = options.statusId;
     }
+    if (options.issueTypeId) {
+      params["issueTypeId"] = options.issueTypeId;
+    }
+    if (options.categoryId) {
+      params["categoryId"] = options.categoryId;
+    }
+    if (options.milestoneId) {
+      params["milestoneId"] = options.milestoneId;
+    }
     if (options.assigneeId) {
       params["assigneeId"] = options.assigneeId;
+    }
+    if (options.priorityId) {
+      params["priorityId"] = options.priorityId;
+    }
+    if (options.keyword) {
+      params["keyword"] = options.keyword;
+    }
+    if (options.sort) {
+      params["sort"] = options.sort;
+    }
+    if (options.order) {
+      params["order"] = options.order;
     }
     if (options.limit) {
       params["count"] = options.limit;
@@ -42,6 +70,46 @@ export class IssueService {
       .map((name) => statuses.find((s) => s.name === name))
       .filter((s): s is Entity.Project.ProjectStatus => s !== undefined)
       .map((s) => s.id);
+  }
+
+  async resolveIssueTypeIds(projectKey: string, names: string[]): Promise<number[]> {
+    const issueTypes = await this.client.getIssueTypes(projectKey);
+    return names
+      .map((name) => issueTypes.find((t: Entity.Issue.IssueType) => t.name === name))
+      .filter((t): t is Entity.Issue.IssueType => t !== undefined)
+      .map((t) => t.id);
+  }
+
+  async resolveCategoryIds(projectKey: string, names: string[]): Promise<number[]> {
+    const categories = await this.client.getCategories(projectKey);
+    return names
+      .map((name) => categories.find((c: Entity.Project.Category) => c.name === name))
+      .filter((c): c is Entity.Project.Category => c !== undefined)
+      .map((c) => c.id);
+  }
+
+  async resolveMilestoneIds(projectKey: string, names: string[]): Promise<number[]> {
+    const versions = await this.client.getVersions(projectKey);
+    return names
+      .map((name) => versions.find((v: Entity.Project.Version) => v.name === name))
+      .filter((v): v is Entity.Project.Version => v !== undefined)
+      .map((v) => v.id);
+  }
+
+  async resolveAssigneeIds(projectKey: string, names: string[]): Promise<number[]> {
+    const members = await this.client.getProjectUsers(projectKey);
+    return names
+      .map((name) => members.find((m: Entity.User.User) => m.name === name))
+      .filter((m): m is Entity.User.User => m !== undefined)
+      .map((m) => m.id);
+  }
+
+  async resolvePriorityIds(names: string[]): Promise<number[]> {
+    const priorities = await this.client.getPriorities();
+    return names
+      .map((name) => priorities.find((p: Entity.Issue.Priority) => p.name === name))
+      .filter((p): p is Entity.Issue.Priority => p !== undefined)
+      .map((p) => p.id);
   }
 
   private async resolveProjectId(projectKey: string): Promise<number> {

--- a/src/services/project.service.ts
+++ b/src/services/project.service.ts
@@ -14,4 +14,24 @@ export class ProjectService {
     }
     return this.client.getProjects(params);
   }
+
+  async getStatuses(projectKey: string): Promise<Entity.Project.ProjectStatus[]> {
+    return this.client.getProjectStatuses(projectKey);
+  }
+
+  async getIssueTypes(projectKey: string): Promise<Entity.Issue.IssueType[]> {
+    return this.client.getIssueTypes(projectKey);
+  }
+
+  async getCategories(projectKey: string): Promise<Entity.Project.Category[]> {
+    return this.client.getCategories(projectKey);
+  }
+
+  async getVersions(projectKey: string): Promise<Entity.Project.Version[]> {
+    return this.client.getVersions(projectKey);
+  }
+
+  async getMembers(projectKey: string): Promise<Entity.User.User[]> {
+    return this.client.getProjectUsers(projectKey);
+  }
 }

--- a/tests/unit/commands/issue/list.test.ts
+++ b/tests/unit/commands/issue/list.test.ts
@@ -13,6 +13,11 @@ describe("issue list command", () => {
     mockIssueService = {
       list: vi.fn().mockResolvedValue([createIssueFixture({ issueKey: "PRJ-1" })]),
       resolveStatusIds: vi.fn().mockResolvedValue([1]),
+      resolveIssueTypeIds: vi.fn().mockResolvedValue([10]),
+      resolveCategoryIds: vi.fn().mockResolvedValue([20]),
+      resolveMilestoneIds: vi.fn().mockResolvedValue([30]),
+      resolveAssigneeIds: vi.fn().mockResolvedValue([40]),
+      resolvePriorityIds: vi.fn().mockResolvedValue([2]),
       getStatuses: vi.fn().mockResolvedValue([]),
     };
     registerIssueListCommand(program, mockIssueService);
@@ -56,6 +61,85 @@ describe("issue list command", () => {
 
   it("-p が未指定の場合エラーになる", async () => {
     await expect(program.parseAsync(["node", "test", "list"])).rejects.toThrow();
+  });
+
+  it("--type で種別フィルタを指定できる", async () => {
+    await program.parseAsync(["node", "test", "list", "-p", "PRJ", "--type", "タスク"]);
+
+    expect(mockIssueService.resolveIssueTypeIds).toHaveBeenCalledWith("PRJ", ["タスク"]);
+    expect(mockIssueService.list).toHaveBeenCalledWith(
+      expect.objectContaining({ issueTypeId: [10] }),
+    );
+  });
+
+  it("--category でカテゴリフィルタを指定できる", async () => {
+    await program.parseAsync(["node", "test", "list", "-p", "PRJ", "--category", "フロントエンド"]);
+
+    expect(mockIssueService.resolveCategoryIds).toHaveBeenCalledWith("PRJ", ["フロントエンド"]);
+    expect(mockIssueService.list).toHaveBeenCalledWith(
+      expect.objectContaining({ categoryId: [20] }),
+    );
+  });
+
+  it("--milestone でマイルストーンフィルタを指定できる", async () => {
+    await program.parseAsync(["node", "test", "list", "-p", "PRJ", "--milestone", "v1.0"]);
+
+    expect(mockIssueService.resolveMilestoneIds).toHaveBeenCalledWith("PRJ", ["v1.0"]);
+    expect(mockIssueService.list).toHaveBeenCalledWith(
+      expect.objectContaining({ milestoneId: [30] }),
+    );
+  });
+
+  it("--assignee で担当者フィルタを指定できる", async () => {
+    await program.parseAsync(["node", "test", "list", "-p", "PRJ", "--assignee", "山田太郎"]);
+
+    expect(mockIssueService.resolveAssigneeIds).toHaveBeenCalledWith("PRJ", ["山田太郎"]);
+    expect(mockIssueService.list).toHaveBeenCalledWith(
+      expect.objectContaining({ assigneeId: [40] }),
+    );
+  });
+
+  it("--priority で優先度フィルタを指定できる", async () => {
+    await program.parseAsync(["node", "test", "list", "-p", "PRJ", "--priority", "高"]);
+
+    expect(mockIssueService.resolvePriorityIds).toHaveBeenCalledWith(["高"]);
+    expect(mockIssueService.list).toHaveBeenCalledWith(
+      expect.objectContaining({ priorityId: [2] }),
+    );
+  });
+
+  it("--keyword でキーワード検索できる", async () => {
+    await program.parseAsync(["node", "test", "list", "-p", "PRJ", "--keyword", "検索ワード"]);
+
+    expect(mockIssueService.list).toHaveBeenCalledWith(
+      expect.objectContaining({ keyword: "検索ワード" }),
+    );
+  });
+
+  it("--sort でソートキーを指定できる", async () => {
+    await program.parseAsync(["node", "test", "list", "-p", "PRJ", "--sort", "created"]);
+
+    expect(mockIssueService.list).toHaveBeenCalledWith(
+      expect.objectContaining({ sort: "created" }),
+    );
+  });
+
+  it("--order でソート順を指定できる", async () => {
+    await program.parseAsync([
+      "node",
+      "test",
+      "list",
+      "-p",
+      "PRJ",
+      "--sort",
+      "created",
+      "--order",
+      "asc",
+    ]);
+
+    expect(mockIssueService.list).toHaveBeenCalledWith(
+      expect.objectContaining({ sort: "created", order: "asc" }),
+    );
   });
 
   it("API呼び出し失敗時にエラーメッセージを表示して exitCode=1", async () => {

--- a/tests/unit/commands/project/categories.test.ts
+++ b/tests/unit/commands/project/categories.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command } from "commander";
+import { registerProjectCategoriesCommand } from "../../../../src/commands/project/categories.js";
+
+describe("project categories command", () => {
+  let program: Command;
+  let mockProjectService: any;
+
+  beforeEach(() => {
+    program = new Command();
+    program.exitOverride();
+    mockProjectService = {
+      getCategories: vi.fn().mockResolvedValue([
+        { id: 1, name: "フロントエンド", displayOrder: 0 },
+        { id: 2, name: "バックエンド", displayOrder: 1 },
+      ]),
+    };
+    registerProjectCategoriesCommand(program, mockProjectService);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("プロジェクトのカテゴリ一覧を表示する", async () => {
+    await program.parseAsync(["node", "test", "categories", "PRJ"]);
+
+    expect(mockProjectService.getCategories).toHaveBeenCalledWith("PRJ");
+    expect(console.log).toHaveBeenCalled();
+    const output = (console.log as any).mock.calls[0][0];
+    expect(output).toContain("フロントエンド");
+    expect(output).toContain("バックエンド");
+  });
+
+  it("--json でJSON出力する", async () => {
+    await program.parseAsync(["node", "test", "categories", "PRJ", "--json"]);
+
+    const output = (console.log as any).mock.calls[0][0];
+    expect(() => JSON.parse(output)).not.toThrow();
+  });
+
+  it("API呼び出し失敗時にエラーメッセージを表示して exitCode=1", async () => {
+    mockProjectService.getCategories.mockRejectedValue(new Error("API error"));
+    const originalExitCode = process.exitCode;
+
+    await program.parseAsync(["node", "test", "categories", "PRJ"]);
+
+    expect(console.error).toHaveBeenCalledWith("API error");
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+  });
+});

--- a/tests/unit/commands/project/index.test.ts
+++ b/tests/unit/commands/project/index.test.ts
@@ -2,9 +2,14 @@ import { describe, it, expect, vi } from "vitest";
 import { createProjectCommand } from "../../../../src/commands/project/index.js";
 
 describe("createProjectCommand", () => {
-  it("project コマンドを作成して list サブコマンドが登録されている", () => {
+  it("project コマンドを作成して全サブコマンドが登録されている", () => {
     const mockProjectService = {
       list: vi.fn(),
+      getStatuses: vi.fn(),
+      getIssueTypes: vi.fn(),
+      getCategories: vi.fn(),
+      getVersions: vi.fn(),
+      getMembers: vi.fn(),
     } as any;
 
     const command = createProjectCommand(mockProjectService);
@@ -12,5 +17,10 @@ describe("createProjectCommand", () => {
     expect(command.name()).toBe("project");
     const subcommands = command.commands.map((c) => c.name());
     expect(subcommands).toContain("list");
+    expect(subcommands).toContain("statuses");
+    expect(subcommands).toContain("types");
+    expect(subcommands).toContain("categories");
+    expect(subcommands).toContain("milestones");
+    expect(subcommands).toContain("members");
   });
 });

--- a/tests/unit/commands/project/members.test.ts
+++ b/tests/unit/commands/project/members.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command } from "commander";
+import { registerProjectMembersCommand } from "../../../../src/commands/project/members.js";
+
+describe("project members command", () => {
+  let program: Command;
+  let mockProjectService: any;
+
+  beforeEach(() => {
+    program = new Command();
+    program.exitOverride();
+    mockProjectService = {
+      getMembers: vi.fn().mockResolvedValue([
+        {
+          id: 1,
+          userId: "user1",
+          name: "ユーザー1",
+          roleType: 1,
+          lang: "ja",
+          mailAddress: "",
+          lastLoginTime: "",
+        },
+        {
+          id: 2,
+          userId: "user2",
+          name: "ユーザー2",
+          roleType: 2,
+          lang: "ja",
+          mailAddress: "",
+          lastLoginTime: "",
+        },
+      ]),
+    };
+    registerProjectMembersCommand(program, mockProjectService);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("プロジェクトのメンバー一覧を表示する", async () => {
+    await program.parseAsync(["node", "test", "members", "PRJ"]);
+
+    expect(mockProjectService.getMembers).toHaveBeenCalledWith("PRJ");
+    expect(console.log).toHaveBeenCalled();
+    const output = (console.log as any).mock.calls[0][0];
+    expect(output).toContain("ユーザー1");
+    expect(output).toContain("ユーザー2");
+  });
+
+  it("--json でJSON出力する", async () => {
+    await program.parseAsync(["node", "test", "members", "PRJ", "--json"]);
+
+    const output = (console.log as any).mock.calls[0][0];
+    expect(() => JSON.parse(output)).not.toThrow();
+  });
+
+  it("API呼び出し失敗時にエラーメッセージを表示して exitCode=1", async () => {
+    mockProjectService.getMembers.mockRejectedValue(new Error("API error"));
+    const originalExitCode = process.exitCode;
+
+    await program.parseAsync(["node", "test", "members", "PRJ"]);
+
+    expect(console.error).toHaveBeenCalledWith("API error");
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+  });
+});

--- a/tests/unit/commands/project/milestones.test.ts
+++ b/tests/unit/commands/project/milestones.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command } from "commander";
+import { registerProjectMilestonesCommand } from "../../../../src/commands/project/milestones.js";
+
+describe("project milestones command", () => {
+  let program: Command;
+  let mockProjectService: any;
+
+  beforeEach(() => {
+    program = new Command();
+    program.exitOverride();
+    mockProjectService = {
+      getVersions: vi.fn().mockResolvedValue([
+        {
+          id: 1,
+          projectId: 100,
+          name: "v1.0",
+          description: "",
+          startDate: "2024-01-01",
+          releaseDueDate: "2024-03-31",
+          archived: false,
+          displayOrder: 0,
+        },
+        {
+          id: 2,
+          projectId: 100,
+          name: "v2.0",
+          description: "",
+          startDate: null,
+          releaseDueDate: null,
+          archived: false,
+          displayOrder: 1,
+        },
+      ]),
+    };
+    registerProjectMilestonesCommand(program, mockProjectService);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("プロジェクトのマイルストーン一覧を表示する", async () => {
+    await program.parseAsync(["node", "test", "milestones", "PRJ"]);
+
+    expect(mockProjectService.getVersions).toHaveBeenCalledWith("PRJ");
+    expect(console.log).toHaveBeenCalled();
+    const output = (console.log as any).mock.calls[0][0];
+    expect(output).toContain("v1.0");
+    expect(output).toContain("v2.0");
+  });
+
+  it("--json でJSON出力する", async () => {
+    await program.parseAsync(["node", "test", "milestones", "PRJ", "--json"]);
+
+    const output = (console.log as any).mock.calls[0][0];
+    expect(() => JSON.parse(output)).not.toThrow();
+  });
+
+  it("API呼び出し失敗時にエラーメッセージを表示して exitCode=1", async () => {
+    mockProjectService.getVersions.mockRejectedValue(new Error("API error"));
+    const originalExitCode = process.exitCode;
+
+    await program.parseAsync(["node", "test", "milestones", "PRJ"]);
+
+    expect(console.error).toHaveBeenCalledWith("API error");
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+  });
+});

--- a/tests/unit/commands/project/statuses.test.ts
+++ b/tests/unit/commands/project/statuses.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command } from "commander";
+import { registerProjectStatusesCommand } from "../../../../src/commands/project/statuses.js";
+
+describe("project statuses command", () => {
+  let program: Command;
+  let mockProjectService: any;
+
+  beforeEach(() => {
+    program = new Command();
+    program.exitOverride();
+    mockProjectService = {
+      getStatuses: vi.fn().mockResolvedValue([
+        { id: 1, projectId: 100, name: "未対応", color: "#ea2c00", displayOrder: 0 },
+        { id: 2, projectId: 100, name: "処理中", color: "#e87758", displayOrder: 1 },
+      ]),
+    };
+    registerProjectStatusesCommand(program, mockProjectService);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("プロジェクトのステータス一覧を表示する", async () => {
+    await program.parseAsync(["node", "test", "statuses", "PRJ"]);
+
+    expect(mockProjectService.getStatuses).toHaveBeenCalledWith("PRJ");
+    expect(console.log).toHaveBeenCalled();
+    const output = (console.log as any).mock.calls[0][0];
+    expect(output).toContain("未対応");
+    expect(output).toContain("処理中");
+  });
+
+  it("--json でJSON出力する", async () => {
+    await program.parseAsync(["node", "test", "statuses", "PRJ", "--json"]);
+
+    const output = (console.log as any).mock.calls[0][0];
+    expect(() => JSON.parse(output)).not.toThrow();
+  });
+
+  it("API呼び出し失敗時にエラーメッセージを表示して exitCode=1", async () => {
+    mockProjectService.getStatuses.mockRejectedValue(new Error("API error"));
+    const originalExitCode = process.exitCode;
+
+    await program.parseAsync(["node", "test", "statuses", "PRJ"]);
+
+    expect(console.error).toHaveBeenCalledWith("API error");
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+  });
+});

--- a/tests/unit/commands/project/types.test.ts
+++ b/tests/unit/commands/project/types.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Command } from "commander";
+import { registerProjectTypesCommand } from "../../../../src/commands/project/types.js";
+
+describe("project types command", () => {
+  let program: Command;
+  let mockProjectService: any;
+
+  beforeEach(() => {
+    program = new Command();
+    program.exitOverride();
+    mockProjectService = {
+      getIssueTypes: vi.fn().mockResolvedValue([
+        { id: 1, projectId: 100, name: "タスク", color: "#7ea800", displayOrder: 0 },
+        { id: 2, projectId: 100, name: "バグ", color: "#e07b9a", displayOrder: 1 },
+      ]),
+    };
+    registerProjectTypesCommand(program, mockProjectService);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("プロジェクトの種別一覧を表示する", async () => {
+    await program.parseAsync(["node", "test", "types", "PRJ"]);
+
+    expect(mockProjectService.getIssueTypes).toHaveBeenCalledWith("PRJ");
+    expect(console.log).toHaveBeenCalled();
+    const output = (console.log as any).mock.calls[0][0];
+    expect(output).toContain("タスク");
+    expect(output).toContain("バグ");
+  });
+
+  it("--json でJSON出力する", async () => {
+    await program.parseAsync(["node", "test", "types", "PRJ", "--json"]);
+
+    const output = (console.log as any).mock.calls[0][0];
+    expect(() => JSON.parse(output)).not.toThrow();
+  });
+
+  it("API呼び出し失敗時にエラーメッセージを表示して exitCode=1", async () => {
+    mockProjectService.getIssueTypes.mockRejectedValue(new Error("API error"));
+    const originalExitCode = process.exitCode;
+
+    await program.parseAsync(["node", "test", "types", "PRJ"]);
+
+    expect(console.error).toHaveBeenCalledWith("API error");
+    expect(process.exitCode).toBe(1);
+    process.exitCode = originalExitCode;
+  });
+});

--- a/tests/unit/formatters/table.formatter.test.ts
+++ b/tests/unit/formatters/table.formatter.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { formatProjectTable } from "../../../src/formatters/table.formatter.js";
+import {
+  formatProjectTable,
+  formatStatusTable,
+  formatIssueTypeTable,
+  formatCategoryTable,
+  formatVersionTable,
+  formatMemberTable,
+} from "../../../src/formatters/table.formatter.js";
 import { createProjectFixture } from "../../helpers/fixtures.js";
 
 describe("formatProjectTable", () => {
@@ -20,5 +27,147 @@ describe("formatProjectTable", () => {
   it("空のプロジェクト一覧に対して空メッセージを返す", () => {
     const result = formatProjectTable([]);
     expect(result).toContain("プロジェクトが見つかりません");
+  });
+});
+
+describe("formatStatusTable", () => {
+  it("ステータス一覧をテーブル形式で返す", () => {
+    const statuses = [
+      { id: 1, projectId: 100, name: "未対応", color: "#ea2c00" as const, displayOrder: 0 },
+      { id: 2, projectId: 100, name: "処理中", color: "#e87758" as const, displayOrder: 1 },
+    ];
+
+    const result = formatStatusTable(statuses);
+    expect(result).toContain("Name");
+    expect(result).toContain("Color");
+    expect(result).toContain("未対応");
+    expect(result).toContain("#ea2c00");
+    expect(result).toContain("処理中");
+  });
+
+  it("空の場合メッセージを返す", () => {
+    const result = formatStatusTable([]);
+    expect(result).toContain("ステータスが見つかりません");
+  });
+});
+
+describe("formatIssueTypeTable", () => {
+  it("種別一覧をテーブル形式で返す", () => {
+    const types = [
+      { id: 1, projectId: 100, name: "タスク", color: "#7ea800", displayOrder: 0 },
+      { id: 2, projectId: 100, name: "バグ", color: "#e07b9a", displayOrder: 1 },
+    ];
+
+    const result = formatIssueTypeTable(types);
+    expect(result).toContain("Name");
+    expect(result).toContain("Color");
+    expect(result).toContain("タスク");
+    expect(result).toContain("バグ");
+  });
+
+  it("空の場合メッセージを返す", () => {
+    const result = formatIssueTypeTable([]);
+    expect(result).toContain("種別が見つかりません");
+  });
+});
+
+describe("formatCategoryTable", () => {
+  it("カテゴリ一覧をテーブル形式で返す", () => {
+    const categories = [
+      { id: 1, name: "フロントエンド", displayOrder: 0 },
+      { id: 2, name: "バックエンド", displayOrder: 1 },
+    ];
+
+    const result = formatCategoryTable(categories);
+    expect(result).toContain("Name");
+    expect(result).toContain("フロントエンド");
+    expect(result).toContain("バックエンド");
+  });
+
+  it("空の場合メッセージを返す", () => {
+    const result = formatCategoryTable([]);
+    expect(result).toContain("カテゴリが見つかりません");
+  });
+});
+
+describe("formatVersionTable", () => {
+  it("バージョン一覧をテーブル形式で返す", () => {
+    const versions = [
+      {
+        id: 1,
+        projectId: 100,
+        name: "v1.0",
+        description: "",
+        startDate: "2024-01-01",
+        releaseDueDate: "2024-03-31",
+        archived: false,
+        displayOrder: 0,
+      },
+      {
+        id: 2,
+        projectId: 100,
+        name: "v2.0",
+        description: "",
+        startDate: null,
+        releaseDueDate: null,
+        archived: true,
+        displayOrder: 1,
+      },
+    ];
+
+    const result = formatVersionTable(versions);
+    expect(result).toContain("Name");
+    expect(result).toContain("StartDate");
+    expect(result).toContain("ReleaseDueDate");
+    expect(result).toContain("Archived");
+    expect(result).toContain("v1.0");
+    expect(result).toContain("2024-01-01");
+    expect(result).toContain("2024-03-31");
+    expect(result).toContain("No");
+    expect(result).toContain("v2.0");
+    expect(result).toContain("Yes");
+  });
+
+  it("空の場合メッセージを返す", () => {
+    const result = formatVersionTable([]);
+    expect(result).toContain("バージョンが見つかりません");
+  });
+});
+
+describe("formatMemberTable", () => {
+  it("メンバー一覧をテーブル形式で返す", () => {
+    const members = [
+      {
+        id: 1,
+        userId: "user1",
+        name: "ユーザー1",
+        roleType: 1,
+        lang: "ja",
+        mailAddress: "",
+        lastLoginTime: "",
+      },
+      {
+        id: 2,
+        userId: "user2",
+        name: "ユーザー2",
+        roleType: 2,
+        lang: "ja",
+        mailAddress: "",
+        lastLoginTime: "",
+      },
+    ];
+
+    const result = formatMemberTable(members);
+    expect(result).toContain("Name");
+    expect(result).toContain("UserId");
+    expect(result).toContain("Role");
+    expect(result).toContain("ユーザー1");
+    expect(result).toContain("user1");
+    expect(result).toContain("ユーザー2");
+  });
+
+  it("空の場合メッセージを返す", () => {
+    const result = formatMemberTable([]);
+    expect(result).toContain("メンバーが見つかりません");
   });
 });

--- a/tests/unit/services/issue.service.test.ts
+++ b/tests/unit/services/issue.service.test.ts
@@ -95,4 +95,217 @@ describe("IssueService", () => {
       expect(ids).toEqual([1, 2]);
     });
   });
+
+  describe("resolveIssueTypeIds", () => {
+    it("種別名からIDに変換する", async () => {
+      const issueTypes = [
+        { id: 10, projectId: 100, name: "タスク", color: "#7ea800", displayOrder: 0 },
+        { id: 11, projectId: 100, name: "バグ", color: "#e07b9a", displayOrder: 1 },
+      ];
+      const mockClient = {
+        getIssueTypes: vi.fn().mockResolvedValue(issueTypes),
+      };
+      const service = new IssueService(mockClient as any);
+
+      const ids = await service.resolveIssueTypeIds("PRJ", ["タスク"]);
+      expect(ids).toEqual([10]);
+      expect(mockClient.getIssueTypes).toHaveBeenCalledWith("PRJ");
+    });
+
+    it("見つからない名前は無視する", async () => {
+      const issueTypes = [
+        { id: 10, projectId: 100, name: "タスク", color: "#7ea800", displayOrder: 0 },
+      ];
+      const mockClient = {
+        getIssueTypes: vi.fn().mockResolvedValue(issueTypes),
+      };
+      const service = new IssueService(mockClient as any);
+
+      const ids = await service.resolveIssueTypeIds("PRJ", ["タスク", "存在しない"]);
+      expect(ids).toEqual([10]);
+    });
+  });
+
+  describe("resolveCategoryIds", () => {
+    it("カテゴリ名からIDに変換する", async () => {
+      const categories = [
+        { id: 20, name: "フロントエンド", displayOrder: 0 },
+        { id: 21, name: "バックエンド", displayOrder: 1 },
+      ];
+      const mockClient = {
+        getCategories: vi.fn().mockResolvedValue(categories),
+      };
+      const service = new IssueService(mockClient as any);
+
+      const ids = await service.resolveCategoryIds("PRJ", ["フロントエンド", "バックエンド"]);
+      expect(ids).toEqual([20, 21]);
+      expect(mockClient.getCategories).toHaveBeenCalledWith("PRJ");
+    });
+  });
+
+  describe("resolveMilestoneIds", () => {
+    it("マイルストーン名からIDに変換する", async () => {
+      const versions = [
+        {
+          id: 30,
+          projectId: 100,
+          name: "v1.0",
+          description: "",
+          startDate: null,
+          releaseDueDate: null,
+          archived: false,
+          displayOrder: 0,
+        },
+        {
+          id: 31,
+          projectId: 100,
+          name: "v2.0",
+          description: "",
+          startDate: null,
+          releaseDueDate: null,
+          archived: false,
+          displayOrder: 1,
+        },
+      ];
+      const mockClient = {
+        getVersions: vi.fn().mockResolvedValue(versions),
+      };
+      const service = new IssueService(mockClient as any);
+
+      const ids = await service.resolveMilestoneIds("PRJ", ["v1.0"]);
+      expect(ids).toEqual([30]);
+      expect(mockClient.getVersions).toHaveBeenCalledWith("PRJ");
+    });
+  });
+
+  describe("resolveAssigneeIds", () => {
+    it("担当者名からIDに変換する", async () => {
+      const members = [
+        {
+          id: 40,
+          userId: "user1",
+          name: "山田太郎",
+          roleType: 1,
+          lang: "ja",
+          mailAddress: "",
+          lastLoginTime: "",
+        },
+        {
+          id: 41,
+          userId: "user2",
+          name: "鈴木花子",
+          roleType: 2,
+          lang: "ja",
+          mailAddress: "",
+          lastLoginTime: "",
+        },
+      ];
+      const mockClient = {
+        getProjectUsers: vi.fn().mockResolvedValue(members),
+      };
+      const service = new IssueService(mockClient as any);
+
+      const ids = await service.resolveAssigneeIds("PRJ", ["山田太郎"]);
+      expect(ids).toEqual([40]);
+      expect(mockClient.getProjectUsers).toHaveBeenCalledWith("PRJ");
+    });
+  });
+
+  describe("resolvePriorityIds", () => {
+    it("優先度名からIDに変換する", async () => {
+      const priorities = [
+        { id: 2, name: "高" },
+        { id: 3, name: "中" },
+        { id: 4, name: "低" },
+      ];
+      const mockClient = {
+        getPriorities: vi.fn().mockResolvedValue(priorities),
+      };
+      const service = new IssueService(mockClient as any);
+
+      const ids = await service.resolvePriorityIds(["高", "中"]);
+      expect(ids).toEqual([2, 3]);
+      expect(mockClient.getPriorities).toHaveBeenCalled();
+    });
+  });
+
+  describe("list with extended options", () => {
+    it("issueTypeIdでフィルタできる", async () => {
+      const mockClient = {
+        getProjects: vi.fn().mockResolvedValue([{ id: 100, projectKey: "PRJ" }]),
+        getIssues: vi.fn().mockResolvedValue([]),
+      };
+      const service = new IssueService(mockClient as any);
+
+      await service.list({ projectKey: "PRJ", issueTypeId: [10] });
+      expect(mockClient.getIssues).toHaveBeenCalledWith(
+        expect.objectContaining({ issueTypeId: [10] }),
+      );
+    });
+
+    it("categoryIdでフィルタできる", async () => {
+      const mockClient = {
+        getProjects: vi.fn().mockResolvedValue([{ id: 100, projectKey: "PRJ" }]),
+        getIssues: vi.fn().mockResolvedValue([]),
+      };
+      const service = new IssueService(mockClient as any);
+
+      await service.list({ projectKey: "PRJ", categoryId: [20] });
+      expect(mockClient.getIssues).toHaveBeenCalledWith(
+        expect.objectContaining({ categoryId: [20] }),
+      );
+    });
+
+    it("milestoneIdでフィルタできる", async () => {
+      const mockClient = {
+        getProjects: vi.fn().mockResolvedValue([{ id: 100, projectKey: "PRJ" }]),
+        getIssues: vi.fn().mockResolvedValue([]),
+      };
+      const service = new IssueService(mockClient as any);
+
+      await service.list({ projectKey: "PRJ", milestoneId: [30] });
+      expect(mockClient.getIssues).toHaveBeenCalledWith(
+        expect.objectContaining({ milestoneId: [30] }),
+      );
+    });
+
+    it("priorityIdでフィルタできる", async () => {
+      const mockClient = {
+        getProjects: vi.fn().mockResolvedValue([{ id: 100, projectKey: "PRJ" }]),
+        getIssues: vi.fn().mockResolvedValue([]),
+      };
+      const service = new IssueService(mockClient as any);
+
+      await service.list({ projectKey: "PRJ", priorityId: [2] });
+      expect(mockClient.getIssues).toHaveBeenCalledWith(
+        expect.objectContaining({ priorityId: [2] }),
+      );
+    });
+
+    it("keywordで検索できる", async () => {
+      const mockClient = {
+        getProjects: vi.fn().mockResolvedValue([{ id: 100, projectKey: "PRJ" }]),
+        getIssues: vi.fn().mockResolvedValue([]),
+      };
+      const service = new IssueService(mockClient as any);
+
+      await service.list({ projectKey: "PRJ", keyword: "検索ワード" });
+      expect(mockClient.getIssues).toHaveBeenCalledWith(
+        expect.objectContaining({ keyword: "検索ワード" }),
+      );
+    });
+
+    it("sortとorderを指定できる", async () => {
+      const mockClient = {
+        getProjects: vi.fn().mockResolvedValue([{ id: 100, projectKey: "PRJ" }]),
+        getIssues: vi.fn().mockResolvedValue([]),
+      };
+      const service = new IssueService(mockClient as any);
+
+      await service.list({ projectKey: "PRJ", sort: "created", order: "asc" });
+      expect(mockClient.getIssues).toHaveBeenCalledWith(
+        expect.objectContaining({ sort: "created", order: "asc" }),
+      );
+    });
+  });
 });

--- a/tests/unit/services/project.service.test.ts
+++ b/tests/unit/services/project.service.test.ts
@@ -33,4 +33,103 @@ describe("ProjectService", () => {
       expect(mockClient.getProjects).toHaveBeenCalledWith({ archived: false });
     });
   });
+
+  describe("getStatuses", () => {
+    it("プロジェクトのステータス一覧を取得する", async () => {
+      const statuses = [
+        { id: 1, projectId: 100, name: "未対応", color: "#ea2c00" as const, displayOrder: 0 },
+        { id: 2, projectId: 100, name: "処理中", color: "#e87758" as const, displayOrder: 1 },
+      ];
+      const mockClient = { getProjectStatuses: vi.fn().mockResolvedValue(statuses) };
+      const service = new ProjectService(mockClient as any);
+
+      const result = await service.getStatuses("PRJ");
+      expect(result).toEqual(statuses);
+      expect(mockClient.getProjectStatuses).toHaveBeenCalledWith("PRJ");
+    });
+  });
+
+  describe("getIssueTypes", () => {
+    it("プロジェクトの種別一覧を取得する", async () => {
+      const issueTypes = [
+        { id: 1, projectId: 100, name: "タスク", color: "#7ea800", displayOrder: 0 },
+        { id: 2, projectId: 100, name: "バグ", color: "#e07b9a", displayOrder: 1 },
+      ];
+      const mockClient = { getIssueTypes: vi.fn().mockResolvedValue(issueTypes) };
+      const service = new ProjectService(mockClient as any);
+
+      const result = await service.getIssueTypes("PRJ");
+      expect(result).toEqual(issueTypes);
+      expect(mockClient.getIssueTypes).toHaveBeenCalledWith("PRJ");
+    });
+  });
+
+  describe("getCategories", () => {
+    it("プロジェクトのカテゴリ一覧を取得する", async () => {
+      const categories = [
+        { id: 1, name: "フロントエンド", displayOrder: 0 },
+        { id: 2, name: "バックエンド", displayOrder: 1 },
+      ];
+      const mockClient = { getCategories: vi.fn().mockResolvedValue(categories) };
+      const service = new ProjectService(mockClient as any);
+
+      const result = await service.getCategories("PRJ");
+      expect(result).toEqual(categories);
+      expect(mockClient.getCategories).toHaveBeenCalledWith("PRJ");
+    });
+  });
+
+  describe("getVersions", () => {
+    it("プロジェクトのバージョン（マイルストーン）一覧を取得する", async () => {
+      const versions = [
+        {
+          id: 1,
+          projectId: 100,
+          name: "v1.0",
+          description: "",
+          startDate: "2024-01-01",
+          releaseDueDate: "2024-03-31",
+          archived: false,
+          displayOrder: 0,
+        },
+      ];
+      const mockClient = { getVersions: vi.fn().mockResolvedValue(versions) };
+      const service = new ProjectService(mockClient as any);
+
+      const result = await service.getVersions("PRJ");
+      expect(result).toEqual(versions);
+      expect(mockClient.getVersions).toHaveBeenCalledWith("PRJ");
+    });
+  });
+
+  describe("getMembers", () => {
+    it("プロジェクトのメンバー一覧を取得する", async () => {
+      const members = [
+        {
+          id: 1,
+          userId: "user1",
+          name: "ユーザー1",
+          roleType: 1,
+          lang: "ja",
+          mailAddress: "u1@example.com",
+          lastLoginTime: "",
+        },
+        {
+          id: 2,
+          userId: "user2",
+          name: "ユーザー2",
+          roleType: 2,
+          lang: "ja",
+          mailAddress: "u2@example.com",
+          lastLoginTime: "",
+        },
+      ];
+      const mockClient = { getProjectUsers: vi.fn().mockResolvedValue(members) };
+      const service = new ProjectService(mockClient as any);
+
+      const result = await service.getMembers("PRJ");
+      expect(result).toEqual(members);
+      expect(mockClient.getProjectUsers).toHaveBeenCalledWith("PRJ");
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- project サブコマンド追加: `statuses`, `types`, `categories`, `milestones`, `members`
- issue list フィルタ拡張: `--type`, `--category`, `--milestone`, `--assignee`, `--priority`, `--keyword`, `--sort`, `--order`
- CLAUDE.md の CLI コマンドセクション更新

## Test plan
- [x] 全115テスト通過
- [x] カバレッジ 98.6%
- [x] tsc --noEmit / ESLint / Prettier 全クリア

🤖 Generated with [Claude Code](https://claude.com/claude-code)