### PR TITLE
fix: formatCommentTable content null クラッシュ修正

### DIFF
--- a/src/formatters/table.formatter.ts
+++ b/src/formatters/table.formatter.ts
@@ -124,7 +124,7 @@ export function formatCommentTable(comments: Entity.Issue.Comment[]): string {
   const separator = "-".repeat(80);
   const formatDate = (iso: string): string =>
     new Date(iso).toISOString().replace("T", " ").slice(0, 19);
-  const firstLine = (s: string): string => s.split("\n")[0];
+  const firstLine = (s: string | null | undefined): string => (s ?? "").split("\n")[0];
 
   const rows = comments.map(
     (c) =>

--- a/tests/unit/formatters/table.formatter.test.ts
+++ b/tests/unit/formatters/table.formatter.test.ts
@@ -229,6 +229,17 @@ describe("formatCommentTable", () => {
     expect(result).toContain("2024-01-15 01:30:00");
   });
 
+  it("content が null のコメントでもクラッシュしない", () => {
+    // Given: content が null のコメント（Backlog API が返す実例あり）
+    const comments = [createCommentFixture({ content: null as unknown as string })];
+
+    // When: formatCommentTable を呼ぶ
+    const result = formatCommentTable(comments);
+
+    // Then: クラッシュせずテーブルが返る
+    expect(result).toContain("Author");
+  });
+
   it("空配列の場合メッセージを返す", () => {
     // Given: 空配列
     // When: formatCommentTable を呼ぶ


### PR DESCRIPTION
## Summary
- Backlog API が `content: null` を返すコメントで `firstLine` が TypeError をスローしクラッシュする問題を修正
- `(s ?? "").split("\n")[0]` で null/undefined を空文字列にフォールバック

## Test plan
- [x] content null の再現テスト追加 (181テスト全通過)
- [x] 実環境で `DX_UHDSYSTEM-1433` のコメント取得を確認

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)