### PR TITLE
fix: --limit バリデーション厳密化 (#12)

### DIFF
--- a/src/commands/helpers.ts
+++ b/src/commands/helpers.ts
@@ -1,0 +1,12 @@
+import { InvalidArgumentError } from "commander";
+
+export function parseLimit(v: string): number {
+  if (!/^\d+$/.test(v)) {
+    throw new InvalidArgumentError("--limit は 1〜100 の整数を指定してください");
+  }
+  const n = parseInt(v, 10);
+  if (n < 1 || n > 100) {
+    throw new InvalidArgumentError("--limit は 1〜100 の整数を指定してください");
+  }
+  return n;
+}

--- a/src/commands/issue/comment.ts
+++ b/src/commands/issue/comment.ts
@@ -3,6 +3,7 @@ import type { IssueService } from "../../services/issue.service.js";
 import { formatCommentCreated } from "../../formatters/detail.formatter.js";
 import { formatCommentTable } from "../../formatters/table.formatter.js";
 import { handleCommandError } from "../../errors/index.js";
+import { parseLimit } from "../helpers.js";
 
 export function registerIssueCommentCommand(program: Command, issueService: IssueService): void {
   const comment = program.command("comment").description("課題コメントの管理");
@@ -29,18 +30,7 @@ export function registerIssueCommentCommand(program: Command, issueService: Issu
   comment
     .command("list <issueKey>")
     .description("課題のコメント一覧を表示する")
-    .option(
-      "--limit <count>",
-      "取得件数",
-      (v: string) => {
-        const n = parseInt(v, 10);
-        if (isNaN(n) || n < 1 || n > 100) {
-          throw new Error("--limit は 1〜100 の整数を指定してください");
-        }
-        return n;
-      },
-      10,
-    )
+    .option("--limit <count>", "取得件数", parseLimit, 10)
     .option("--json", "JSON形式で出力する")
     .action(async (issueKey: string, options: { limit: number; json?: boolean }) => {
       try {

--- a/src/commands/issue/list.ts
+++ b/src/commands/issue/list.ts
@@ -2,6 +2,7 @@ import type { Command } from "commander";
 import type { IssueService, IssueListOptions } from "../../services/issue.service.js";
 import { formatIssueTable } from "../../formatters/table.formatter.js";
 import { handleCommandError } from "../../errors/index.js";
+import { parseLimit } from "../helpers.js";
 
 interface IssueListCommandOptions {
   project: string;
@@ -32,7 +33,7 @@ export function registerIssueListCommand(program: Command, issueService: IssueSe
     .option("--keyword <text>", "キーワード検索")
     .option("--sort <key>", "ソートキー")
     .option("--order <order>", "ソート順 (asc|desc)")
-    .option("--limit <number>", "取得件数", parseInt)
+    .option("--limit <number>", "取得件数", parseLimit)
     .option("--json", "JSON形式で出力する")
     .action(async (options: IssueListCommandOptions) => {
       try {

--- a/tests/unit/commands/helpers.test.ts
+++ b/tests/unit/commands/helpers.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { InvalidArgumentError } from "commander";
+import { parseLimit } from "../../../src/commands/helpers.js";
+
+describe("parseLimit", () => {
+  it("有効な数値文字列を数値に変換する", () => {
+    expect(parseLimit("10")).toBe(10);
+  });
+
+  it("数値1を受け付ける", () => {
+    expect(parseLimit("1")).toBe(1);
+  });
+
+  it("数値100を受け付ける", () => {
+    expect(parseLimit("100")).toBe(100);
+  });
+
+  it("非数値文字を含む文字列でエラーになる", () => {
+    expect(() => parseLimit("10abc")).toThrow(InvalidArgumentError);
+  });
+
+  it("完全な非数値文字列でエラーになる", () => {
+    expect(() => parseLimit("abc")).toThrow(InvalidArgumentError);
+  });
+
+  it("0でエラーになる", () => {
+    expect(() => parseLimit("0")).toThrow(InvalidArgumentError);
+  });
+
+  it("101でエラーになる", () => {
+    expect(() => parseLimit("101")).toThrow(InvalidArgumentError);
+  });
+
+  it("負数でエラーになる", () => {
+    expect(() => parseLimit("-1")).toThrow(InvalidArgumentError);
+  });
+
+  it("小数でエラーになる", () => {
+    expect(() => parseLimit("1.5")).toThrow(InvalidArgumentError);
+  });
+});

--- a/tests/unit/commands/issue/comment.test.ts
+++ b/tests/unit/commands/issue/comment.test.ts
@@ -160,6 +160,12 @@ describe("issue comment command", () => {
       ).rejects.toThrow();
     });
 
+    it("--limit 10abc で非数値文字を含む場合エラーになる", async () => {
+      await expect(
+        program.parseAsync(["node", "test", "comment", "list", "PRJ-1", "--limit", "10abc"]),
+      ).rejects.toThrow();
+    });
+
     it("API呼び出し失敗時にエラーメッセージを表示して exitCode=1", async () => {
       mockIssueService.listComments.mockRejectedValue(new Error("コメント取得に失敗しました"));
       const originalExitCode = process.exitCode;

--- a/tests/unit/commands/issue/list.test.ts
+++ b/tests/unit/commands/issue/list.test.ts
@@ -142,6 +142,12 @@ describe("issue list command", () => {
     );
   });
 
+  it("--limit 10abc で非数値文字を含む場合エラーになる", async () => {
+    await expect(
+      program.parseAsync(["node", "test", "list", "-p", "PRJ", "--limit", "10abc"]),
+    ).rejects.toThrow();
+  });
+
   it("API呼び出し失敗時にエラーメッセージを表示して exitCode=1", async () => {
     mockIssueService.list.mockRejectedValue(new Error("API connection failed"));
     const originalExitCode = process.exitCode;


### PR DESCRIPTION
## Summary
- `parseInt("10abc", 10)` が `10` を返し `--limit 10abc` が警告なく受理される問題を修正
- 共通 `parseLimit` ヘルパーを `src/commands/helpers.ts` に導入し、正規表現 `/^\d+$/` + 範囲チェック (1-100) で厳密にバリデーション
- `issue list` と `issue comment list` の両方に適用

## Test plan
- [x] `parseLimit` ユニットテスト 9件 (有効値、非数値、範囲外、小数、負数)
- [x] `issue comment list --limit 10abc` エラーテスト
- [x] `issue list --limit 10abc` エラーテスト
- [x] 全192テスト通過
- [x] `tsc --noEmit` エラー0件
- [x] ESLint エラー0件
- [x] Prettier 準拠

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)